### PR TITLE
Add localtime template tag

### DIFF
--- a/resonant_utils/templates/localtime.html
+++ b/resonant_utils/templates/localtime.html
@@ -1,0 +1,6 @@
+<local-time datetime="{{ dt.isoformat }}"
+  month="short"
+  day="numeric"
+  year="numeric"
+  hour="numeric"
+  minute="numeric"></local-time>

--- a/resonant_utils/templatetags/resonant_utils.py
+++ b/resonant_utils/templatetags/resonant_utils.py
@@ -7,6 +7,7 @@ from django import template
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+    from datetime import datetime
 
 register = template.Library()
 
@@ -44,3 +45,17 @@ def pretty_json(value: Any, indent: int | None = None) -> str:
     <pre>{{ my_object|pretty_json:4 }}</pre>
     """
     return json.dumps(value, indent=indent)
+
+
+@register.inclusion_tag("localtime.html")
+def localtime(value: datetime) -> dict[str, datetime]:
+    """
+    Include the datetime as a local-time formatted value.
+
+    Sample usage::
+    {% load resonant_utils %}
+    <pre>{% localtime object.creation_time %}</pre>
+    """
+    return {
+        "dt": value,
+    }


### PR DESCRIPTION
Fixes #37 

This requires adding the time-elements script (https://github.com/github/time-elements) to the pages this is used on.